### PR TITLE
AC-12_05_19-1

### DIFF
--- a/Studio Prototypes/Assets/Scenes/MainMenu.unity
+++ b/Studio Prototypes/Assets/Scenes/MainMenu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -161,7 +161,7 @@ MonoBehaviour:
   m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}
@@ -622,7 +622,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 237.5}
+  m_AnchoredPosition: {x: 0, y: 194}
   m_SizeDelta: {x: 687.88, y: 97.91}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &928558792

--- a/Studio Prototypes/Assets/Scripts/AC_WeekEnd.cs
+++ b/Studio Prototypes/Assets/Scripts/AC_WeekEnd.cs
@@ -10,6 +10,12 @@ public class AC_WeekEnd : MonoBehaviour
     //
     private AC_SchoolStatsManager schoolStats;
     private AC_GameOver gameOver;
+    private AC_YearEnd yearEnd;
+    private JH_Time_UI timeUI;
+
+    public GameObject repPanel;
+    public Color repColour;
+    public float repOpacity;
 
     // Variables to hold the current student that is being checked, stats.
     public int currentTotalHAP;
@@ -27,16 +33,19 @@ public class AC_WeekEnd : MonoBehaviour
     {
         // So the this script doesnt lose the reference to the JH_Student_Manager script.
         studentSpawner = GameObject.Find("Game").GetComponent<JH_Student_Manager>();
-
         //
         schoolStats = GameObject.Find("SchoolStatDropDown").GetComponent<AC_SchoolStatsManager>();
         //
         gameOver = GameObject.Find("GameManager").GetComponent<AC_GameOver>();
+
+        yearEnd = GameObject.Find("GameManager").GetComponent<AC_YearEnd>();
+        // So the this script doesnt lose the reference to the JH_Control_Time script.
+        timeUI = GameObject.Find("Date/TimePanel").GetComponent<JH_Time_UI>();
     }
 
     private void Start()
     {
-
+        
     }
     // Update is called once per frame.
     void Update()
@@ -47,7 +56,7 @@ public class AC_WeekEnd : MonoBehaviour
     public void WeeklyStudentUpdate()
     {
         Debug.Log("Week Update");
-        
+        yearEnd.currentWeek = timeUI.in_week;
         //
         Debug.Log("Reducing Rep");
         schoolStats.schoolRep--;
@@ -70,11 +79,36 @@ public class AC_WeekEnd : MonoBehaviour
             gameOver.EarlyRetirementEnd();
         }
 
+        if (currentRep < 25)
+        {
+           repOpacity = 0.5f;
+        }
+        else if (currentRep >= 20 && currentRep < 35)
+        {
+            repOpacity = 0.4f;
+        }
+        else if (currentRep >= 35 && currentRep < 50)
+        {
+            repOpacity = 0.3f;
+        }
+        else if (currentRep >= 50 && currentRep < 65)
+        {
+            repOpacity = 0.2f;
+        }
+        else
+        {
+            repOpacity = 0.1f;
+        }
+
+        repColour.a = repOpacity;
+        repPanel.GetComponent<Image>().color = repColour;
+
         currentTotalHAP = 0;
         currentTotalALI = 0;
 
         for (int i = 0; i < studentSpawner.go_studentList.Length; i++)
         {
+            
             // Gets total of all student stats.
             if (studentSpawner.go_studentList[i] != null)
             {

--- a/Studio Prototypes/Assets/Scripts/AC_YearEnd.cs
+++ b/Studio Prototypes/Assets/Scripts/AC_YearEnd.cs
@@ -23,6 +23,7 @@ public class AC_YearEnd : MonoBehaviour
     public int superPassGrade;
     // Variables that hold the number of students that graduate.
     public int[] numberOfGraduates;
+    public int[] numberOfNonGraduates;
     public int numberOfSuperGraduates;
     public int graduatesForYear;
     public int nongraduatesForYear;
@@ -84,7 +85,6 @@ public class AC_YearEnd : MonoBehaviour
     public void FirstYear()
     {
         currentYear = timeUI.in_year;
-        currentWeek = timeUI.in_week;
         yearSize = studentSpawner.numberOfStudents;
         currentRep = schoolStats.schoolRep;
     }
@@ -152,12 +152,13 @@ public class AC_YearEnd : MonoBehaviour
                 }
                 else
                 {
-                    nongraduatesForYear++;
+                    numberOfNonGraduates[currentYear - 2]++;
                 }
             }
         }
 
         graduatesForYear = numberOfGraduates[currentYear - 2];
+        nongraduatesForYear = numberOfNonGraduates[currentYear - 2];
 
         PassPercentage();
 

--- a/Studio Prototypes/ProjectSettings/QualitySettings.asset
+++ b/Studio Prototypes/ProjectSettings/QualitySettings.asset
@@ -216,4 +216,9 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     excludedTargetPlatforms: []
-  m_PerPlatformDefaultQuality: {}
+  m_PerPlatformDefaultQuality:
+    Android: 0
+    Standalone: 0
+    WebGL: 0
+    iPhone: 0
+    tvOS: 0


### PR DESCRIPTION
- Reputation now has a panel that becomes more and less opaque based on what the schools reputation is.
- Number of non-graduates now calculated for gameover.
- For JH_Time_UI, in_week is now public so it can be used by ovi's data manager.